### PR TITLE
Move sidebar initialization after patient metadata

### DIFF
--- a/Karina_Chat_2.py
+++ b/Karina_Chat_2.py
@@ -45,9 +45,6 @@ supabase: Client = create_client(supabase_url, supabase_key)
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 st.session_state["openai_client"] = client
 
-show_sidebar()
-
-
 # Zugriff via Streamlit Secrets
 # nextcloud_url = st.secrets["nextcloud"]["url"]
 # nextcloud_user = st.secrets["nextcloud"]["user"]
@@ -291,6 +288,8 @@ Patientensimulation – {st.session_state.diagnose_szenario}
 
 {st.session_state.diagnose_features}
 """
+
+show_sidebar()
 
 # Anweisungen anzeigen
 zeige_instruktionen_vor_start()


### PR DESCRIPTION
## Summary
- move the `show_sidebar()` call to after the patient metadata is populated so the sidebar has all required context

## Testing
- `streamlit run Karina_Chat_2.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68dd2fd3100c83298552ea1a5936331c