### PR TITLE
Add gender-aware patient wording across modules

### DIFF
--- a/befundmodul.py
+++ b/befundmodul.py
@@ -1,7 +1,10 @@
 from module.token_counter import init_token_counters, add_usage
+from module.patient_language import get_patient_forms
 
 def generiere_befund(client, szenario, neue_diagnostik):
-    prompt = f"""Die Patientin hat laut Szenario: {szenario}.
+    patient_forms = get_patient_forms()
+
+    prompt = f"""{patient_forms.phrase("nom", capitalize=True)} hat laut Szenario: {szenario}.
 Folgende zusätzliche Diagnostik wurde angefordert:
 {neue_diagnostik}
 

--- a/feedbackmodul.py
+++ b/feedbackmodul.py
@@ -1,4 +1,5 @@
 from module.token_counter import init_token_counters, add_usage
+from module.patient_language import get_patient_forms
 
 def feedback_erzeugen(
     client,
@@ -12,10 +13,12 @@ def feedback_erzeugen(
     anzahl_termine,
     diagnose_szenario
 ):
-    prompt = f"""
-Ein Medizinstudierender hat eine vollständige virtuelle Fallbesprechung mit einer Patientin durchgeführt. Du bist ein erfahrener medizinischer Prüfer.
+    patient_forms = get_patient_forms()
 
-Beurteile ausschließlich die Eingaben und Entscheidungen des Studierenden – NICHT die Antworten der Patientin oder automatisch generierte Inhalte.
+    prompt = f"""
+Ein Medizinstudierender hat eine vollständige virtuelle Fallbesprechung mit {patient_forms.phrase("dat", article="indefinite")} durchgeführt. Du bist ein erfahrener medizinischer Prüfer.
+
+Beurteile ausschließlich die Eingaben und Entscheidungen des Studierenden – NICHT die Antworten {patient_forms.phrase("gen")} oder automatisch generierte Inhalte.
 
 Die zugrunde liegende Erkrankung im Szenario lautet: **{diagnose_szenario}**.
 

--- a/module/patient_language.py
+++ b/module/patient_language.py
@@ -1,0 +1,142 @@
+"""Hilfsfunktionen für genderadaptive Patientenformulierungen."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import streamlit as st
+
+_CASE_ALIASES = {
+    "nom": "nom",
+    "nominative": "nom",
+    "acc": "acc",
+    "accusative": "acc",
+    "dat": "dat",
+    "dative": "dat",
+    "gen": "gen",
+    "genitive": "gen",
+}
+
+
+@dataclass(frozen=True)
+class PatientForms:
+    """Enthält sprachliche Formen für die Patient:innenansprache."""
+
+    definite: Dict[str, str]
+    indefinite: Dict[str, str]
+    plural: str
+    compound_stem: str
+    base: str
+
+    def phrase(
+        self,
+        case: str = "nominative",
+        *,
+        article: str = "definite",
+        adjective: str | None = None,
+        capitalize: bool = False,
+    ) -> str:
+        """Gibt die gewünschte Form zurück."""
+
+        case_key = _CASE_ALIASES.get(case.lower())
+        if case_key is None:
+            raise ValueError(f"Unsupported grammatical case: {case}")
+
+        if article == "definite":
+            phrase = self.definite[case_key]
+        elif article == "indefinite":
+            phrase = self.indefinite[case_key]
+        else:
+            raise ValueError(f"Unsupported article type: {article}")
+
+        if adjective:
+            parts = phrase.split(" ", 1)
+            if len(parts) == 2:
+                phrase = f"{parts[0]} {adjective} {parts[1]}"
+            else:
+                phrase = f"{adjective} {phrase}"
+
+        if capitalize and phrase:
+            phrase = phrase[0].upper() + phrase[1:]
+
+        return phrase
+
+    def plural_phrase(self, adjective: str | None = None) -> str:
+        """Pluralbezeichnung mit optionalem Adjektiv."""
+
+        if adjective:
+            return f"{adjective} {self.plural}"
+        return self.plural
+
+    def compound(self, suffix: str) -> str:
+        """Bildet zusammengesetzte Substantive."""
+
+        return f"{self.compound_stem}{suffix}"
+
+    def base_word(self) -> str:
+        """Gibt das Grundwort (Singular) zurück."""
+
+        return self.base
+
+
+def get_patient_forms() -> PatientForms:
+    """Ermittelt passende sprachliche Formen anhand des gespeicherten Geschlechts."""
+
+    gender = str(st.session_state.get("patient_gender", "")).strip().lower()
+
+    if gender == "m":
+        definite = {
+            "nom": "der Patient",
+            "acc": "den Patienten",
+            "dat": "dem Patienten",
+            "gen": "des Patienten",
+        }
+        indefinite = {
+            "nom": "ein Patient",
+            "acc": "einen Patienten",
+            "dat": "einem Patienten",
+            "gen": "eines Patienten",
+        }
+        plural = "Patienten"
+        compound_stem = "Patienten"
+        base = "Patient"
+    elif gender == "w":
+        definite = {
+            "nom": "die Patientin",
+            "acc": "die Patientin",
+            "dat": "der Patientin",
+            "gen": "der Patientin",
+        }
+        indefinite = {
+            "nom": "eine Patientin",
+            "acc": "eine Patientin",
+            "dat": "einer Patientin",
+            "gen": "einer Patientin",
+        }
+        plural = "Patientinnen"
+        compound_stem = "Patientinnen"
+        base = "Patientin"
+    else:
+        definite = {
+            "nom": "die Patientin oder der Patient",
+            "acc": "die Patientin oder den Patienten",
+            "dat": "der Patientin oder dem Patienten",
+            "gen": "der Patientin oder des Patienten",
+        }
+        indefinite = {
+            "nom": "eine Patientin oder ein Patient",
+            "acc": "eine Patientin oder einen Patienten",
+            "dat": "einer Patientin oder einem Patienten",
+            "gen": "einer Patientin oder eines Patienten",
+        }
+        plural = "Patientinnen oder Patienten"
+        compound_stem = "Patient:innen"
+        base = "Patient:in"
+
+    return PatientForms(
+        definite=definite,
+        indefinite=indefinite,
+        plural=plural,
+        compound_stem=compound_stem,
+        base=base,
+    )

--- a/module/startinfo.py
+++ b/module/startinfo.py
@@ -1,26 +1,29 @@
 import streamlit as st
 
+from module.patient_language import get_patient_forms
+
 def zeige_instruktionen_vor_start():
     st.session_state.setdefault("instruktion_bestätigt", False)
+    patient_forms = get_patient_forms()
 
     if not st.session_state.instruktion_bestätigt:
         st.markdown(f"""
 #### Instruktionen für Studierende:
-Sie übernehmen die Rolle einer Ärztin oder eines Arztes im Gespräch mit der virtuellen Patientin {st.session_state.patient_name}, die sich in Ihrer hausärztlichen Sprechstunde vorstellt. 
+Sie übernehmen die Rolle einer Ärztin oder eines Arztes im Gespräch mit {patient_forms.phrase("dat", adjective="virtuellen")} {st.session_state.patient_name}, die sich in Ihrer hausärztlichen Sprechstunde vorstellt.
 Ihr Ziel ist es, durch gezielte Anamnese und klinisches Denken eine Verdachtsdiagnose zu stellen sowie ein sinnvolles diagnostisches und therapeutisches Vorgehen zu entwickeln.
 
 #### 🔍 Ablauf:
 
-1. **Stellen Sie jederzeit Fragen an die Patientin** – geben Sie diese im Chat ein.
+1. **Stellen Sie jederzeit Fragen an {patient_forms.phrase("acc")}** – geben Sie diese im Chat ein.
 2. Wenn Sie genug Informationen gesammelt haben, führen Sie eine **körperliche Untersuchung** durch.
 3. Formulieren Sie Ihre **Differentialdiagnosen** und wählen Sie geeignete **diagnostische Maßnahmen**.
 4. Nach Erhalt der Befunde treffen Sie Ihre **endgültige Diagnose** und machen einen **Therapievorschlag**.
 5. Abschließend erhalten Sie ein **automatisches Feedback** zu Ihrem Vorgehen.
 
-> 💬 **Hinweis:** Sie können die Patientin auch nach der ersten Diagnostik weiter befragen –  
+> 💬 **Hinweis:** Sie können {patient_forms.phrase("acc")} auch nach der ersten Diagnostik weiter befragen –
 z. B. bei neuen Verdachtsmomenten oder zur gezielten Klärung offener Fragen.
 
-Im Wartezimmer sitzen weitere Patientinnen mit anderen Krankheitsbildern, die Sie durch einen erneuten Aufruf der App kennenlernen können.
+Im Wartezimmer sitzen weitere {patient_forms.plural_phrase()} mit anderen Krankheitsbildern, die Sie durch einen erneuten Aufruf der App kennenlernen können.
 
 ---
 - **Überprüfen Sie alle Angaben und Hinweise der Kommunikation auf Richtigkeit.** 

--- a/module/untersuchungsmodul.py
+++ b/module/untersuchungsmodul.py
@@ -1,6 +1,11 @@
+from module.patient_language import get_patient_forms
+
+
 def generiere_koerperbefund(client, diagnose_szenario, diagnose_features, koerper_befund_tip):
+    patient_forms = get_patient_forms()
+
     prompt = f"""
-Die Patientin hat eine zufällig simulierte Erkrankung. Diese lautet: {diagnose_szenario}.
+{patient_forms.phrase("nom", capitalize=True)} hat eine zufällig simulierte Erkrankung. Diese lautet: {diagnose_szenario}.
 Weitere relevante anamnestische Hinweise: {diagnose_features}
 Zusatzinformationen: {koerper_befund_tip}
 Erstelle einen körperlichen Untersuchungsbefund, der zu dieser Erkrankung passt, ohne sie explizit zu nennen oder zu diagnostizieren. Berücksichtige Befunde, die sich aus den Zusatzinformationen ergeben könnten. 

--- a/pages/20_Impressum.py
+++ b/pages/20_Impressum.py
@@ -1,12 +1,14 @@
 import streamlit as st
 from module.sidebar import show_sidebar
 from module.footer import copyright_footer
+from module.patient_language import get_patient_forms
 
 copyright_footer()
 show_sidebar()
 
 def show_impressum():
-    st.markdown("""
+    patient_forms = get_patient_forms()
+    st.markdown(f"""
     ## Impressum
     
     **Projektleitung**  
@@ -19,7 +21,7 @@ def show_impressum():
     E-Mail: jens.walldorf@uk-halle.de  
 
     ---
-    ⚠️ Bitte beachten Sie, dass Sie mit einem **experimentellen, KI-basierten, simulierten Patientinnenmodell** kommunizieren, welches **ausschließlich zu Lehrzwecken** konzipiert ist. 
+    ⚠️ Bitte beachten Sie, dass Sie mit einem **experimentellen, KI-basierten, simulierten {patient_forms.compound("modell")}** kommunizieren, welches **ausschließlich zu Lehrzwecken** konzipiert ist.
     
     Wichtiges Lernziel bei der Verwendung der App ist es unter anderem, die Limitationen (**Fehlinterpretationen, falsche Informationen**) in den von der KI generierten Antworten zu identifizieren.
     


### PR DESCRIPTION
## Summary
- add a shared helper to derive patient wording from the stored gender
- update prompts and UI text to use gender-aware phrasing across relevant modules
- adjust the impressum warning to reuse the gender-adaptive language helper

## Testing
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_68dd373b46ac8329adbd3f45df8d08a7