### PR TITLE
Make start instructions use gender-aware relative clause

### DIFF
--- a/module/patient_language.py
+++ b/module/patient_language.py
@@ -27,6 +27,7 @@ class PatientForms:
     plural: str
     compound_stem: str
     base: str
+    relative_pronouns: Dict[str, str]
 
     def phrase(
         self,
@@ -78,6 +79,15 @@ class PatientForms:
 
         return self.base
 
+    def relative_pronoun(self, case: str = "nominative") -> str:
+        """Gibt das passende Relativpronomen für den gewünschten Kasus zurück."""
+
+        case_key = _CASE_ALIASES.get(case.lower())
+        if case_key is None:
+            raise ValueError(f"Unsupported grammatical case: {case}")
+
+        return self.relative_pronouns[case_key]
+
 
 def get_patient_forms() -> PatientForms:
     """Ermittelt passende sprachliche Formen anhand des gespeicherten Geschlechts."""
@@ -100,6 +110,12 @@ def get_patient_forms() -> PatientForms:
         plural = "Patienten"
         compound_stem = "Patienten"
         base = "Patient"
+        relative_pronouns = {
+            "nom": "der",
+            "acc": "den",
+            "dat": "dem",
+            "gen": "dessen",
+        }
     elif gender == "w":
         definite = {
             "nom": "die Patientin",
@@ -116,6 +132,12 @@ def get_patient_forms() -> PatientForms:
         plural = "Patientinnen"
         compound_stem = "Patientinnen"
         base = "Patientin"
+        relative_pronouns = {
+            "nom": "die",
+            "acc": "die",
+            "dat": "der",
+            "gen": "deren",
+        }
     else:
         definite = {
             "nom": "die Patientin oder der Patient",
@@ -132,6 +154,12 @@ def get_patient_forms() -> PatientForms:
         plural = "Patientinnen oder Patienten"
         compound_stem = "Patient:innen"
         base = "Patient:in"
+        relative_pronouns = {
+            "nom": "die",
+            "acc": "die",
+            "dat": "denen",
+            "gen": "deren",
+        }
 
     return PatientForms(
         definite=definite,
@@ -139,4 +167,5 @@ def get_patient_forms() -> PatientForms:
         plural=plural,
         compound_stem=compound_stem,
         base=base,
+        relative_pronouns=relative_pronouns,
     )

--- a/module/startinfo.py
+++ b/module/startinfo.py
@@ -9,7 +9,7 @@ def zeige_instruktionen_vor_start():
     if not st.session_state.instruktion_bestätigt:
         st.markdown(f"""
 #### Instruktionen für Studierende:
-Sie übernehmen die Rolle einer Ärztin oder eines Arztes im Gespräch mit {patient_forms.phrase("dat", adjective="virtuellen")} {st.session_state.patient_name}, die sich in Ihrer hausärztlichen Sprechstunde vorstellt.
+Sie übernehmen die Rolle einer Ärztin oder eines Arztes im Gespräch mit {patient_forms.phrase("dat", adjective="virtuellen")} {st.session_state.patient_name}, {patient_forms.relative_pronoun()} sich in Ihrer hausärztlichen Sprechstunde vorstellt.
 Ihr Ziel ist es, durch gezielte Anamnese und klinisches Denken eine Verdachtsdiagnose zu stellen sowie ein sinnvolles diagnostisches und therapeutisches Vorgehen zu entwickeln.
 
 #### 🔍 Ablauf:


### PR DESCRIPTION
## Summary
- add gender-aware relative pronoun support to the patient language helper
- update the start instructions to use the adaptive relative pronoun

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd3d26e2e88329b0a9ddd35d15ec29