### PR TITLE
Add admin access shortcut, toggle, and admin placeholder page

### DIFF
--- a/module/sidebar.py
+++ b/module/sidebar.py
@@ -100,9 +100,15 @@ def show_sidebar():
             "final_diagnose" in st.session_state and
             "therapie_vorschlag" in st.session_state
         ):
-            st.page_link("pages/6_Feedback_und_Evaluation.py", label="📝 Feedback & Download")  
+            st.page_link("pages/6_Feedback_und_Evaluation.py", label="📝 Feedback & Download")
 
         st.page_link("pages/20_Impressum.py", label="Impressum und Hinweise", icon="📰")
+
+        if st.session_state.get("is_admin"):
+            st.markdown(
+                '<div style="margin-top:0.5rem;"><a href="?page=21_Admin" style="color:#d00000; font-weight:bold;">🔑 Adminbereich</a></div>',
+                unsafe_allow_html=True,
+            )
 
         st.markdown("---")
         st.caption("🔒 Weitere Seiten erscheinen automatisch, sobald diagnostische Schritte abgeschlossen wurden.")

--- a/pages/1_Anamnese.py
+++ b/pages/1_Anamnese.py
@@ -46,6 +46,17 @@ with st.form(key="eingabe_formular", clear_on_submit=True):
     submit_button = st.form_submit_button(label="Absenden")
 
 if submit_button and user_input:
+    admin_code = st.secrets.get("admin_code") if hasattr(st, "secrets") else None
+    if admin_code and user_input.strip() == str(admin_code):
+        st.session_state["is_admin"] = True
+        st.success("🔑 Adminzugang aktiviert. Du wirst weitergeleitet …")
+        try:
+            st.switch_page("pages/21_Admin.py")
+        except Exception:
+            st.experimental_set_query_params(page="21_Admin")
+            st.rerun()
+        st.stop()
+
     st.session_state.messages.append({"role": "user", "content": user_input})
     with st.spinner(f"{st.session_state.patient_name} antwortet..."):
         try:

--- a/pages/21_Admin.py
+++ b/pages/21_Admin.py
@@ -1,0 +1,40 @@
+import streamlit as st
+
+from module.sidebar import show_sidebar
+from module.footer import copyright_footer
+
+
+copyright_footer()
+show_sidebar()
+
+if not st.session_state.get("is_admin"):
+    st.error("🚫 Kein Zugriff: Dieser Bereich steht nur Administrator*innen zur Verfügung.")
+    st.info("Bitte gib in der Anamnese den gültigen Admin-Code ein, um Zugriff zu erhalten.")
+    st.page_link("pages/1_Anamnese.py", label="⬅ Zurück zur Anamnese")
+    st.stop()
+
+st.title("Adminbereich")
+st.markdown(
+    "Hier entstehen künftig die administrativen Werkzeuge zur Verwaltung und Auswertung des Trainings.")
+
+st.markdown("---")
+st.subheader("Adminmodus")
+st.write("Der Adminmodus ist aktiv. Bei Bedarf kannst du ihn hier wieder deaktivieren.")
+
+if st.button("🔒 Adminmodus beenden", type="primary"):
+    st.session_state["is_admin"] = False
+    try:
+        st.switch_page("pages/1_Anamnese.py")
+    except Exception:
+        st.experimental_set_query_params(page="1_Anamnese")
+        st.rerun()
+
+st.markdown("---")
+st.header("📊 Auswertungen")
+st.info("Platzhalter für statistische Übersichten und Reports.")
+
+st.header("🛠️ Einstellungen")
+st.info("Platzhalter für Konfigurationsoptionen und Benutzerverwaltung.")
+
+st.header("🗂️ Ressourcen")
+st.info("Platzhalter für Uploads, Downloads und Materialverwaltung.")


### PR DESCRIPTION
## Summary
- detect the admin code in the anamnesis form to unlock an admin session and redirect to the new admin page
- add a guarded admin page with placeholder sections for future tools
- surface a red-highlighted admin link in the sidebar whenever the admin session is active
- add a button on the admin page to disable the admin session and return to the anamnesis form

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e017887f1c8329ab0204a1599cfecb