### PR TITLE
Add Supabase feedback export for admin page

### DIFF
--- a/module/admin_data.py
+++ b/module/admin_data.py
@@ -1,0 +1,124 @@
+"""Helper utilities for admin data exports."""
+from __future__ import annotations
+
+from datetime import datetime
+from io import BytesIO
+from typing import Dict, Iterable, Tuple
+
+import pandas as pd
+import streamlit as st
+from cryptography.fernet import Fernet, InvalidToken
+from supabase import Client, create_client
+
+
+class FeedbackExportError(Exception):
+    """Custom error raised for feedback export issues."""
+
+
+def _get_supabase_client() -> Client:
+    """Create and return a Supabase client using Streamlit secrets.
+
+    Raises:
+        FeedbackExportError: If Supabase credentials are missing or invalid.
+
+    Returns:
+        Client: An authenticated Supabase client instance.
+    """
+
+    supabase_config = st.secrets.get("supabase")
+    if not supabase_config:
+        raise FeedbackExportError("Supabase-Konfiguration fehlt in st.secrets.")
+
+    try:
+        url = supabase_config["url"]
+        key = supabase_config["key"]
+    except KeyError as exc:
+        raise FeedbackExportError("Supabase-Zugangsdaten sind unvollständig.") from exc
+
+    try:
+        client = create_client(url, key)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise FeedbackExportError(f"Supabase-Verbindung fehlgeschlagen: {exc!r}") from exc
+
+    return client
+
+
+def _get_matrikel_fernet() -> Fernet:
+    """Create the Fernet instance for matrikel token decryption."""
+
+    supabase_config = st.secrets.get("supabase")
+    if not supabase_config or "matrikel_key" not in supabase_config:
+        raise FeedbackExportError("Supabase-Geheimnis 'matrikel_key' fehlt.")
+
+    matrikel_key = supabase_config["matrikel_key"]
+    if not matrikel_key:
+        raise FeedbackExportError("Supabase 'matrikel_key' ist leer.")
+
+    try:
+        return Fernet(matrikel_key)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise FeedbackExportError("Supabase 'matrikel_key' ist ungültig.") from exc
+
+
+def _decrypt_matrikel_values(
+    rows: Iterable[Dict[str, object]],
+    fernet: Fernet,
+) -> None:
+    """Mutate rows in-place by decrypting 'Matrikel' tokens if present."""
+
+    for row in rows:
+        token = row.get("Matrikel")
+        if not token:
+            row["Matrikel"] = "(nicht angegeben)"
+            continue
+
+        if not isinstance(token, str):
+            row["Matrikel"] = "(ungültiges Format)"
+            continue
+
+        try:
+            decrypted = fernet.decrypt(token.encode("utf-8")).decode("utf-8")
+            row["Matrikel"] = decrypted
+        except InvalidToken:
+            row["Matrikel"] = "(Entschlüsselung fehlgeschlagen)"
+        except Exception:  # pragma: no cover - defensive
+            row["Matrikel"] = "(Entschlüsselung fehlgeschlagen)"
+
+
+def build_feedback_export() -> Tuple[bytes, str]:
+    """Fetch GPT feedback entries and return an Excel export as bytes.
+
+    Raises:
+        FeedbackExportError: If accessing Supabase or the secrets fails.
+
+    Returns:
+        Tuple[bytes, str]: The Excel file bytes and a suggested filename.
+    """
+
+    client = _get_supabase_client()
+    fernet = _get_matrikel_fernet()
+
+    try:
+        response = client.table("feedback_gpt").select("*").execute()
+    except Exception as exc:  # pragma: no cover - defensive
+        raise FeedbackExportError(f"Abruf aus Supabase fehlgeschlagen: {exc!r}") from exc
+
+    if getattr(response, "error", None):
+        raise FeedbackExportError(f"Supabase meldet einen Fehler: {response.error}")
+
+    rows: Iterable[Dict[str, object]] = response.data or []
+    rows = [dict(row) for row in rows]
+
+    _decrypt_matrikel_values(rows, fernet)
+
+    df = pd.DataFrame(rows)
+
+    if df.empty:
+        df = pd.DataFrame(columns=["ID", "Matrikel", "datum", "uhrzeit"])
+
+    buffer = BytesIO()
+    df.to_excel(buffer, index=False)
+    buffer.seek(0)
+
+    filename = f"feedback_gpt_{datetime.now():%Y%m%d_%H%M%S}.xlsx"
+    return buffer.getvalue(), filename

--- a/pages/21_Admin.py
+++ b/pages/21_Admin.py
@@ -1,5 +1,6 @@
 import streamlit as st
 
+from module.admin_data import FeedbackExportError, build_feedback_export
 from module.sidebar import show_sidebar
 from module.footer import copyright_footer
 
@@ -31,6 +32,30 @@ if st.button("🔒 Adminmodus beenden", type="primary"):
 
 st.markdown("---")
 st.header("📊 Auswertungen")
+st.subheader("💾 Feedback-Export")
+
+feedback_excel = None
+feedback_filename = "feedback_gpt.xlsx"
+
+with st.spinner("Supabase-Daten werden geladen..."):
+    try:
+        feedback_excel, feedback_filename = build_feedback_export()
+    except FeedbackExportError as exc:
+        feedback_excel = None
+        st.error(f"🚫 Export nicht möglich: {exc}")
+    except Exception as exc:  # pragma: no cover - defensive
+        feedback_excel = None
+        st.error(f"⚠️ Unerwarteter Fehler beim Export: {exc}")
+
+if feedback_excel:
+    st.download_button(
+        "⬇️ Feedback-Daten als Excel herunterladen",
+        data=feedback_excel,
+        file_name=feedback_filename,
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        type="primary",
+    )
+
 st.info("Platzhalter für statistische Übersichten und Reports.")
 
 st.header("🛠️ Einstellungen")


### PR DESCRIPTION
## Summary
- add a helper module that loads GPT feedback entries from Supabase, decrypts matrikel tokens, and renders an Excel export
- surface the export on the admin page with download support and clear error handling

## Testing
- python -m compileall module/admin_data.py pages/21_Admin.py

------
https://chatgpt.com/codex/tasks/task_e_68e01b5505f88329bdacb0235b432049