### PR TITLE
Prevent Supabase writes when offline

### DIFF
--- a/Karina_Chat_2.py
+++ b/Karina_Chat_2.py
@@ -25,6 +25,7 @@ from befundmodul import generiere_befund
 from module.sidebar import show_sidebar
 from module.startinfo import zeige_instruktionen_vor_start
 from module.token_counter import init_token_counters, add_usage
+from module.offline import display_offline_banner, is_offline
 from module.fallverwaltung import (
     DEFAULT_FALLDATEI_URL,
     fallauswahl_prompt,
@@ -56,8 +57,13 @@ def initialisiere_session_state():
     st.session_state.setdefault("final_feedback", "") #test
     st.session_state.setdefault("feedback_prompt_final", "") #test
     st.session_state.setdefault("final_diagnose", "") #test
+    st.session_state.setdefault("offline_mode", False)
 
 def speichere_gpt_feedback_in_supabase():
+    if is_offline():
+        st.info("🔌 Offline-Modus: Feedback wird nicht in Supabase gespeichert.")
+        return
+
     jetzt = datetime.now()
     start = st.session_state.get("startzeit", jetzt)
     dauer_min = round((jetzt - start).total_seconds() / 60, 1)
@@ -135,6 +141,8 @@ if st.session_state.get("diagnose_szenario"):
     prepare_fall_session_state()
 
 show_sidebar()
+
+display_offline_banner()
 
 # Anweisungen anzeigen
 zeige_instruktionen_vor_start()

--- a/befundmodul.py
+++ b/befundmodul.py
@@ -1,7 +1,11 @@
 from module.token_counter import init_token_counters, add_usage
 from module.patient_language import get_patient_forms
+from module.offline import get_offline_befund, is_offline
 
 def generiere_befund(client, szenario, neue_diagnostik):
+    if is_offline():
+        return get_offline_befund(neue_diagnostik)
+
     patient_forms = get_patient_forms()
 
     prompt = f"""{patient_forms.phrase("nom", capitalize=True)} hat laut Szenario: {szenario}.

--- a/diagnostikmodul.py
+++ b/diagnostikmodul.py
@@ -5,6 +5,7 @@ import streamlit as st
 from openai import OpenAI
 from sprachmodul import sprach_check
 from befundmodul import generiere_befund
+from module.offline import is_offline
 
 def aktualisiere_diagnostik_zusammenfassung(start_runde=2):
     """Erstellt die kumulative Zusammenfassung aller Diagnostik- und Befund-Runden und speichert sie im SessionState."""
@@ -70,12 +71,16 @@ def diagnostik_und_befunde_routine(client: OpenAI, start_runde=2, weitere_diagno
 
                 szenario = st.session_state.get("diagnose_szenario", "")
 
-                with st.spinner("GPT erstellt Befunde..."):
-                    befund = generiere_befund(client, szenario, neue_diagnostik)                
-                    st.session_state[befund_key] = befund
-                    st.session_state["diagnostik_runden_gesamt"] = runde
-                    st.session_state["diagnostik_aktiv"] = False  # zurücksetzen
-                    st.rerun()
+                if is_offline():
+                    befund = generiere_befund(client, szenario, neue_diagnostik)
+                else:
+                    with st.spinner("GPT erstellt Befunde..."):
+                        befund = generiere_befund(client, szenario, neue_diagnostik)
+
+                st.session_state[befund_key] = befund
+                st.session_state["diagnostik_runden_gesamt"] = runde
+                st.session_state["diagnostik_aktiv"] = False  # zurücksetzen
+                st.rerun()
 
 # 🔁 Zusammenfassung aller Runden
     aktualisiere_diagnostik_zusammenfassung(start_runde)

--- a/feedbackmodul.py
+++ b/feedbackmodul.py
@@ -1,5 +1,6 @@
 from module.token_counter import init_token_counters, add_usage
 from module.patient_language import get_patient_forms
+from module.offline import get_offline_feedback, is_offline
 
 def feedback_erzeugen(
     client,
@@ -13,6 +14,9 @@ def feedback_erzeugen(
     anzahl_termine,
     diagnose_szenario
 ):
+    if is_offline():
+        return get_offline_feedback(diagnose_szenario)
+
     patient_forms = get_patient_forms()
 
     prompt = f"""

--- a/module/feedback_ui.py
+++ b/module/feedback_ui.py
@@ -2,6 +2,7 @@ import streamlit as st
 from datetime import datetime
 from supabase import create_client, Client
 from cryptography.fernet import Fernet, InvalidToken
+from module.offline import is_offline
 
 # Supabase initialisieren (Erwartung: in st.secrets definiert)
 supabase_url = st.secrets["supabase"]["url"]
@@ -36,6 +37,12 @@ def _encrypt_matrikel(matrikel: str) -> str | None:
 def student_feedback():
     st.markdown("---")
     st.subheader("🗣 Ihr Feedback zur Simulation")
+
+    offline_active = is_offline()
+    if offline_active:
+        st.info(
+            "🔌 Offline-Modus aktiv: Ihr Feedback wird derzeit nicht an Supabase übermittelt."
+        )
 
     if st.session_state.get("student_evaluation_done"):
         st.success("✅ Vielen Dank! Ihr Feedback wurde bereits gespeichert.")
@@ -80,7 +87,11 @@ def student_feedback():
     bugs = st.text_area("💬 Welche Ungenauigkeiten oder Fehler sind Ihnen aufgefallen (optional):", "")
     kommentar = st.text_area("💬 Freitext (optional):", "")
 
-    if st.button("📩 Feedback absenden"):
+    if st.button("📩 Feedback absenden", disabled=offline_active):
+        if offline_active:
+            st.info("🔌 Offline-Modus: Feedback konnte nicht gespeichert werden.")
+            return
+
         eintrag = {
             "note_realismus": f1,
             "note_anamnese": f2,

--- a/module/gpt_feedback.py
+++ b/module/gpt_feedback.py
@@ -3,8 +3,14 @@ from supabase import create_client
 from datetime import datetime
 # import json
 from module.token_counter import init_token_counters, get_token_sums
+from module.offline import is_offline
 
 def speichere_gpt_feedback_in_supabase():
+    if is_offline():
+        st.info("🔌 Offline-Modus: Feedback wird nicht in Supabase gespeichert.")
+        st.session_state.pop("feedback_row_id", None)
+        return
+
     jetzt = datetime.now()
     start = st.session_state.get("startzeit", jetzt)
     dauer_min = round((jetzt - start).total_seconds() / 60, 1)

--- a/module/offline.py
+++ b/module/offline.py
@@ -1,0 +1,73 @@
+import streamlit as st
+
+
+def is_offline() -> bool:
+    """Return True if the application runs without OpenAI connectivity."""
+    return bool(st.session_state.get("offline_mode", False))
+
+
+def display_offline_banner() -> None:
+    """Show a prominent banner while the offline mode is active."""
+    if is_offline():
+        st.warning(
+            "🔌 Offline-Modus aktiv: Antworten stammen aus statischen Platzhaltern. "
+            "Es werden keine OpenAI-Anfragen gesendet und keine Tokens gezählt."
+        )
+
+
+def get_offline_patient_reply(patient_name: str) -> str:
+    """Provide a short canned answer for the anamnesis chat while offline."""
+    name = patient_name or "Die simulierte Patientin"
+    return (
+        "(Offline) {name} antwortet ruhig:"\
+        .format(name=name)
+        + "\n"
+        + "Ich kann dir derzeit nur die Basisinformationen aus dem Szenario schildern. "
+          "Bitte prüfe den Steckbrief und die bisherigen Notizen, bis der Online-Modus wieder aktiv ist."
+    )
+
+
+def get_offline_koerperbefund() -> str:
+    """Return a generic but plausible examination report for offline usage."""
+    return (
+        "🔌 Offline-Modus – standardisierter Befund"\
+        "\n\n"
+        "**Allgemeinzustand:** wach, orientiert, kooperativ; Vitalparameter im Normbereich."\
+        "\n**Abdomen:** weich, kein Druckschmerz, Darmgeräusche regelrecht."\
+        "\n**Auskultation Herz/Lunge:** Herztöne rein, rhythmisch; Vesikuläratmen beidseits ohne Nebengeräusche."\
+        "\n**Haut:** rosig, warm, keine Auffälligkeiten."\
+        "\n**Extremitäten:** frei beweglich, keine Ödeme, periphere Pulse tastbar."
+    )
+
+
+def get_offline_befund(neue_diagnostik: str) -> str:
+    """Build a placeholder diagnostics report while offline."""
+    angefordert = neue_diagnostik.strip() or "(keine zusätzlichen Angaben gemacht)"
+    return (
+        "🔌 Offline-Modus – vereinfachter Befundbericht"\
+        "\n\n"
+        f"Angeforderte Untersuchungen:\n{angefordert}\n\n"
+        "Ergebnisse (statisch generiert):\n"
+        "- Laborwerte im Referenzbereich, keine pathologischen Abweichungen.\n"
+        "- Bildgebung ohne richtungsweisende Befunde.\n"
+        "- Funktionsdiagnostik unauffällig."
+    )
+
+
+def get_offline_feedback(diagnose_szenario: str) -> str:
+    """Provide a static feedback note while offline."""
+    szenario = diagnose_szenario or "dem aktuellen Szenario"
+    return (
+        "🔌 Offline-Modus – kein automatisches GPT-Feedback verfügbar."\
+        "\n"
+        f"Bewerte deine Bearbeitung von {szenario} anhand der Checkliste:"
+        "\n1. Wurden die relevanten Anamnesepunkte erfragt?"
+        "\n2. Passten Diagnostik und Differentialdiagnosen zusammen?"
+        "\n3. Ist die finale Diagnose nachvollziehbar und das Therapiekonzept begründet?"
+        "\nNutze die Lösungen oder besprich den Fall im Team, sobald der Online-Modus wieder aktiv ist."
+    )
+
+
+def get_offline_sprachcheck(text_input: str) -> str:
+    """Return the original text when no correction can be generated."""
+    return text_input

--- a/module/untersuchungsmodul.py
+++ b/module/untersuchungsmodul.py
@@ -1,7 +1,11 @@
 from module.patient_language import get_patient_forms
+from module.offline import get_offline_koerperbefund, is_offline
 
 
 def generiere_koerperbefund(client, diagnose_szenario, diagnose_features, koerper_befund_tip):
+    if is_offline():
+        return get_offline_koerperbefund()
+
     patient_forms = get_patient_forms()
 
     prompt = f"""

--- a/pages/21_Admin.py
+++ b/pages/21_Admin.py
@@ -3,6 +3,7 @@ import streamlit as st
 from module.admin_data import FeedbackExportError, build_feedback_export
 from module.sidebar import show_sidebar
 from module.footer import copyright_footer
+from module.offline import display_offline_banner, is_offline
 from module.fallverwaltung import (
     fallauswahl_prompt,
     lade_fallbeispiele,
@@ -13,6 +14,7 @@ from module.fallverwaltung import (
 
 copyright_footer()
 show_sidebar()
+display_offline_banner()
 
 if not st.session_state.get("is_admin"):
     st.error("🚫 Kein Zugriff: Dieser Bereich steht nur Administrator*innen zur Verfügung.")
@@ -23,6 +25,26 @@ if not st.session_state.get("is_admin"):
 st.title("Adminbereich")
 st.markdown(
     "Hier entstehen künftig die administrativen Werkzeuge zur Verwaltung und Auswertung des Trainings.")
+
+st.markdown("---")
+st.subheader("Verbindungsmodus")
+current_offline = is_offline()
+offline_toggle = st.toggle(
+    "Offline-Modus aktivieren",
+    value=current_offline,
+    help=(
+        "Im Offline-Modus werden statische Platzhalter statt GPT-Antworten verwendet. "
+        "Die OpenAI-API wird dabei nicht angesprochen."
+    ),
+    key="admin_offline_toggle",
+)
+
+if offline_toggle != current_offline:
+    st.session_state["offline_mode"] = offline_toggle
+    if offline_toggle:
+        st.info("🔌 Offline-Modus aktiviert. Alle Seiten nutzen jetzt statische Inhalte.")
+    else:
+        st.success("🌐 Online-Modus reaktiviert. GPT-Antworten werden wieder live generiert.")
 
 st.markdown("---")
 st.subheader("Adminmodus")

--- a/pages/4_Diagnostik_und_Befunde.py
+++ b/pages/4_Diagnostik_und_Befunde.py
@@ -3,8 +3,10 @@ from module.sidebar import show_sidebar
 from module.footer import copyright_footer
 from diagnostikmodul import diagnostik_und_befunde_routine
 from befundmodul import generiere_befund
+from module.offline import display_offline_banner, is_offline
 
 show_sidebar()
+display_offline_banner()
 
 # st.subheader("Diagnostik und Befunde")
 
@@ -50,10 +52,15 @@ if (
                 diagnose_szenario = st.session_state.diagnose_szenario
                 client = st.session_state.get("openai_client")
 
-                with st.spinner("Befunde werden generiert..."):
+                if is_offline():
                     befund = generiere_befund(client, diagnose_szenario, diagnostik_eingabe)
+                else:
+                    with st.spinner("Befunde werden generiert..."):
+                        befund = generiere_befund(client, diagnose_szenario, diagnostik_eingabe)
 
                 st.session_state.befunde = befund
+                if is_offline():
+                    st.info("🔌 Offline-Befund gespeichert. Sobald der Online-Modus aktiv ist, kannst du neue KI-Befunde abrufen.")
                 st.success("✅ Befunde generiert")
                 st.rerun()
 
@@ -114,12 +121,17 @@ if (
 
         szenario = st.session_state.get("diagnose_szenario", "")
         client = st.session_state.get("openai_client")
-        with st.spinner("GPT erstellt Befunde..."):
+        if is_offline():
             befund = generiere_befund(client, szenario, neue_diagnostik)
-            st.session_state[f"befunde_runde_{neuer_termin}"] = befund
-            st.session_state["diagnostik_runden_gesamt"] = neuer_termin
-            st.session_state["diagnostik_aktiv"] = False
-            st.rerun()
+        else:
+            with st.spinner("GPT erstellt Befunde..."):
+                befund = generiere_befund(client, szenario, neue_diagnostik)
+        st.session_state[f"befunde_runde_{neuer_termin}"] = befund
+        st.session_state["diagnostik_runden_gesamt"] = neuer_termin
+        st.session_state["diagnostik_aktiv"] = False
+        if is_offline():
+            st.info("🔌 Offline-Befund gespeichert. Schalte den Online-Modus wieder ein, um echte GPT-Ergebnisse zu erhalten.")
+        st.rerun()
 
 # Button für neue Diagnostik
 if (

--- a/pages/5_Diagnose_und_Therapie.py
+++ b/pages/5_Diagnose_und_Therapie.py
@@ -2,8 +2,10 @@ import streamlit as st
 from module.sidebar import show_sidebar
 from sprachmodul import sprach_check
 from module.footer import copyright_footer
+from module.offline import display_offline_banner, is_offline
 
 show_sidebar()
+display_offline_banner()
 
 st.subheader("Diagnose und Therapie")
 
@@ -26,6 +28,8 @@ else:
         client = st.session_state.get("openai_client")
         st.session_state.final_diagnose = sprach_check(input_diag, client)
         st.session_state.therapie_vorschlag = sprach_check(input_therapie, client)
+        if is_offline():
+            st.info("🔌 Offline-Modus: Eingaben wurden ohne GPT-Korrektur übernommen.")
         st.rerun()
 
 # # Nur für Admin sichtbar:

--- a/sprachmodul.py
+++ b/sprachmodul.py
@@ -1,9 +1,13 @@
 import streamlit as st
 from module.token_counter import init_token_counters, add_usage
+from module.offline import get_offline_sprachcheck, is_offline
 
 def sprach_check(text_input, client):
     if not text_input.strip():
         return ""
+
+    if is_offline():
+        return get_offline_sprachcheck(text_input)
 
     prompt = f"""
 Bitte überprüfe die folgenden stichpunktartigen medizinischen Fachbegriffe hinsichtlich Orthographie und Zeichensetzung, schreibe Abkürzungen aus.


### PR DESCRIPTION
## Summary
- add offline guards before Supabase inserts in the main app and helper modules
- disable student feedback submissions and show context messages while offline
- inform the feedback page that Supabase storage is skipped whenever offline mode is active

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e0489ac06083298b141edaca2a550c