### PR TITLE
Reset state after leaving offline mode and clean admin page

### DIFF
--- a/module/offline.py
+++ b/module/offline.py
@@ -10,7 +10,7 @@ def display_offline_banner() -> None:
     """Show a prominent banner while the offline mode is active."""
     if is_offline():
         st.warning(
-            "🔌 Offline-Modus aktiv: Antworten stammen aus statischen Platzhaltern. "
+            "Offline-Modus aktiv: Antworten stammen aus statischen Platzhaltern. "
             "Es werden keine OpenAI-Anfragen gesendet und keine Tokens gezählt."
         )
 
@@ -19,8 +19,7 @@ def get_offline_patient_reply(patient_name: str) -> str:
     """Provide a short canned answer for the anamnesis chat while offline."""
     name = patient_name or "Die simulierte Patientin"
     return (
-        "(Offline) {name} antwortet ruhig:"\
-        .format(name=name)
+        "(Offline) {name} antwortet ruhig:".format(name=name)
         + "\n"
         + "Ich kann dir derzeit nur die Basisinformationen aus dem Szenario schildern. "
           "Bitte prüfe den Steckbrief und die bisherigen Notizen, bis der Online-Modus wieder aktiv ist."
@@ -30,12 +29,12 @@ def get_offline_patient_reply(patient_name: str) -> str:
 def get_offline_koerperbefund() -> str:
     """Return a generic but plausible examination report for offline usage."""
     return (
-        "🔌 Offline-Modus – standardisierter Befund"\
+        "Offline-Modus – standardisierter Befund"
         "\n\n"
-        "**Allgemeinzustand:** wach, orientiert, kooperativ; Vitalparameter im Normbereich."\
-        "\n**Abdomen:** weich, kein Druckschmerz, Darmgeräusche regelrecht."\
-        "\n**Auskultation Herz/Lunge:** Herztöne rein, rhythmisch; Vesikuläratmen beidseits ohne Nebengeräusche."\
-        "\n**Haut:** rosig, warm, keine Auffälligkeiten."\
+        "**Allgemeinzustand:** wach, orientiert, kooperativ; Vitalparameter im Normbereich."
+        "\n**Abdomen:** weich, kein Druckschmerz, Darmgeräusche regelrecht."
+        "\n**Auskultation Herz/Lunge:** Herztöne rein, rhythmisch; Vesikuläratmen beidseits ohne Nebengeräusche."
+        "\n**Haut:** rosig, warm, keine Auffälligkeiten."
         "\n**Extremitäten:** frei beweglich, keine Ödeme, periphere Pulse tastbar."
     )
 
@@ -44,7 +43,7 @@ def get_offline_befund(neue_diagnostik: str) -> str:
     """Build a placeholder diagnostics report while offline."""
     angefordert = neue_diagnostik.strip() or "(keine zusätzlichen Angaben gemacht)"
     return (
-        "🔌 Offline-Modus – vereinfachter Befundbericht"\
+        "Offline-Modus – vereinfachter Befundbericht"
         "\n\n"
         f"Angeforderte Untersuchungen:\n{angefordert}\n\n"
         "Ergebnisse (statisch generiert):\n"
@@ -58,7 +57,7 @@ def get_offline_feedback(diagnose_szenario: str) -> str:
     """Provide a static feedback note while offline."""
     szenario = diagnose_szenario or "dem aktuellen Szenario"
     return (
-        "🔌 Offline-Modus – kein automatisches GPT-Feedback verfügbar."\
+        "Offline-Modus – kein automatisches GPT-Feedback verfügbar."
         "\n"
         f"Bewerte deine Bearbeitung von {szenario} anhand der Checkliste:"
         "\n1. Wurden die relevanten Anamnesepunkte erfragt?"


### PR DESCRIPTION
## Summary
- restart the app state when the offline mode switch is disabled so a fresh case is loaded
- simplify the admin page layout by removing placeholder sections and emojis
- align offline helper texts with the reduced visual style

## Testing
- python -m compileall module pages Karina_Chat_2.py

------
https://chatgpt.com/codex/tasks/task_e_68e04c1604148329bf8291dce046dd97