### PR TITLE
Move admin login to Impressum page

### DIFF
--- a/pages/1_Anamnese.py
+++ b/pages/1_Anamnese.py
@@ -52,17 +52,6 @@ with st.form(key="eingabe_formular", clear_on_submit=True):
     submit_button = st.form_submit_button(label="Absenden")
 
 if submit_button and user_input:
-    admin_code = st.secrets.get("admin_code") if hasattr(st, "secrets") else None
-    if admin_code and user_input.strip() == str(admin_code):
-        st.session_state["is_admin"] = True
-        st.success("🔑 Adminzugang aktiviert. Du wirst weitergeleitet …")
-        try:
-            st.switch_page("pages/21_Admin.py")
-        except Exception:
-            st.experimental_set_query_params(page="21_Admin")
-            st.rerun()
-        st.stop()
-
     st.session_state.messages.append({"role": "user", "content": user_input})
     if is_offline():
         reply = get_offline_patient_reply(st.session_state.get("patient_name", ""))

--- a/pages/20_Impressum.py
+++ b/pages/20_Impressum.py
@@ -35,9 +35,31 @@ def show_impressum():
     Für die Richtigkeit der Inhalte kann entsprechend keine Haftung übernommen werden.
 
     ---
-    
-    
+
+
     Stand: August 2025
     """)
+
+    with st.form(key="admin_login_form"):
+        st.markdown("---")
+        st.markdown("### Admin-Zugang")
+        admin_password = st.text_input("Admin-Passwort", type="password")
+        submitted = st.form_submit_button("Anmelden")
+
+    if submitted:
+        admin_code = st.secrets.get("admin_code") if hasattr(st, "secrets") else None
+        if admin_code is None:
+            st.error("🚫 Es ist kein Admin-Code konfiguriert.")
+        elif admin_password.strip() == str(admin_code):
+            st.session_state["is_admin"] = True
+            st.success("🔑 Adminzugang aktiviert. Du wirst weitergeleitet …")
+            try:
+                st.switch_page("pages/21_Admin.py")
+            except Exception:
+                st.experimental_set_query_params(page="21_Admin")
+                st.rerun()
+            st.stop()
+        else:
+            st.error("❌ Das eingegebene Passwort ist nicht korrekt.")
 
 show_impressum()


### PR DESCRIPTION
## Summary
- remove the inline admin password check from the Anamnese chat handling
- add an admin login form to the Impressum page with password validation and redirection

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0539f619883298e03cce505e7f16e