### PR TITLE
Exclude ecological/ economic content from therapy detail and place eco block after detail CTA

### DIFF
--- a/module/feedback_detail.py
+++ b/module/feedback_detail.py
@@ -306,12 +306,34 @@ def _generate_detail_text(section: FeedbackSection, context: Dict[str, Any]) -> 
     if client is None:
         raise RuntimeError("OpenAI-Client fehlt im Session-State (openai_client).")
 
+    # Abschnittsspezifische Leitplanke für Punkt 6:
+    # Im Detailtext zu "Therapiekonzept und Setting" sollen Ökologie/Ökonomie
+    # ausdrücklich außen vor bleiben. Dafür nutzen wir zwei Mechanismen:
+    # 1) Wir geben dem Modell nur den therapeutischen Kernteil als Kernaussage.
+    # 2) Wir ergänzen eine explizite Negativregel im Prompt.
+    #
+    # Debug-Hilfe bei Bedarf (temporär aktivieren):
+    # st.write("DEBUG therapie_setting core", detail_core_statement)
+    detail_core_statement = section.body
+    section_specific_rules = ""
+    if section.key == "therapie_setting":
+        eco_marker = re.search(
+            r"(?im)^\s*(?:\*\*)?\s*ökologische\s*/\s*ökonomische\s+aspekte\s*:?(?:\*\*)?\s*$",
+            section.body,
+        )
+        if eco_marker:
+            detail_core_statement = section.body[: eco_marker.start()].strip()
+        section_specific_rules = (
+            "- Für diesen Unterpunkt keine Aussagen zu ökologischen oder ökonomischen Aspekten "
+            "machen; Fokus ausschließlich auf Therapieansatz und Versorgungssetting."
+        )
+
     prompt = f"""
 Erstelle eine praxisnahe, nicht-personalisierte Vertiefung auf Deutsch für einen Feedback-Unterpunkt.
 
 Unterpunkt: {section.title}
 Kernaussage aus dem kompakten Feedback:
-{section.body}
+{detail_core_statement}
 
 Strukturierter Abschnittskontext (nur erlaubte Felder):
 {context}
@@ -325,6 +347,7 @@ Verbindliche Ausgabe-Regeln:
 - Nutze Fetthebung sparsam und gezielt (keine ganzen Sätze fett markieren).
 - Nur Inhalte verwenden, die zum Unterpunkt und zum gelieferten Kontext passen.
 - Keine Quellenangaben, keine Leitliniennummern, keine erfundenen Details.
+{section_specific_rules}
 - Umfang kompakt halten (ca. 120–170 Wörter).
 """.strip()
 
@@ -561,7 +584,31 @@ def render_feedback_with_details(feedback_text: str) -> None:
 
     for section in sections:
         st.markdown(f"**{section.number}. {section.title}**")
-        st.markdown(section.body)
+
+        # Für Abschnitt 6 kann das Hauptfeedback zusätzlich den separaten Block
+        # "Ökologische/ökonomische Aspekte" enthalten. Der Detail-Button für
+        # "Therapiekonzept und Setting" soll laut UI-Vorgabe *vor* diesem Block
+        # stehen. Daher trennen wir den Abschnittskörper in:
+        # - `section_body_before_details`: fachlicher Therapieteil (oberhalb CTA)
+        # - `section_body_after_details`: Ökologie/Ökonomie-Hinweise (unterhalb CTA)
+        #
+        # Debug-Hilfe bei unerwarteter Darstellung:
+        # Temporär `st.write("DEBUG split", section.key, section_body_before_details, section_body_after_details)`
+        # aktivieren, um die Trennlogik direkt im UI zu prüfen.
+        section_body_before_details = section.body
+        section_body_after_details = ""
+        if section.key == "therapie_setting":
+            eco_marker = re.search(
+                r"(?im)^\s*(?:\*\*)?\s*ökologische\s*/\s*ökonomische\s+aspekte\s*:?(?:\*\*)?\s*$",
+                section.body,
+            )
+            if eco_marker:
+                split_index = eco_marker.start()
+                section_body_before_details = section.body[:split_index].strip()
+                section_body_after_details = section.body[split_index:].strip()
+
+        if section_body_before_details:
+            st.markdown(section_body_before_details)
 
         # Ladezustand wird explizit pro Unterpunkt im Session-State geführt.
         # Damit ist die UI robust gegenüber Reruns und nicht mehr vom Selectbox-Wert abhängig.
@@ -696,6 +743,11 @@ def render_feedback_with_details(feedback_text: str) -> None:
                     _save_open_event(supabase, int(feedback_id), section, detail_text)
                 except Exception as exc:
                     st.warning(f"⚠️ Speichern des Öffnungs-Events fehlgeschlagen: {exc}")
+
+        # Der ausgelagerte Ökologie/Ökonomie-Block wird bewusst nach dem
+        # Detail-CTA (und ggf. nach geladenem Detailtext) gerendert.
+        if section_body_after_details:
+            st.markdown(section_body_after_details)
 
         # Wichtig für korrektes Ausblenden:
         # Der Detailtext wird absichtlich *nicht* automatisch aus dem Cache


### PR DESCRIPTION
### Motivation
- Ensure that the detail text for the "Therapiekonzept und Setting" section focuses only on therapeutic content and explicitly omits ecological/økonomische Aspekte. 
- Keep the UI behavior consistent by placing the detail-load CTA before any auxiliary "Ökologische/ökonomische Aspekte" block so the CTA controls the detailed clinical text only. 
- Provide small debugging helpers and a deterministic extraction rule to avoid leaking the eco/eco content into AI-generated detail text.

### Description
- Added logic in `_generate_detail_text` to derive a `detail_core_statement` that trims any trailing "Ökologische/ökonomische Aspekte" marker from `section.body` and injects a section-specific negative rule into the prompt for `therapie_setting` so the model must not mention ecological/economic aspects. 
- Rewrote the prompt to use `detail_core_statement` instead of the raw `section.body` and to append `section_specific_rules` for enforcement of the negative constraint. 
- In `render_feedback_with_details`, split `section.body` for `therapie_setting` into `section_body_before_details` and `section_body_after_details` using a regex marker, render the before-part and CTA first, then (optionally) render the after-part so the eco/eco block appears after the detail CTA. 
- Added explanatory comments and temporary debug hints near the new extraction/splitting code and prompt construction.

### Testing
- No automated tests were added or executed specifically for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8aa8f4f7c8329959e1d3d26839f9f)